### PR TITLE
[master] Deprecated insideOut flag

### DIFF
--- a/src/InkRouter/Models/Attributes/FoldingAttributes.php
+++ b/src/InkRouter/Models/Attributes/FoldingAttributes.php
@@ -23,6 +23,7 @@ class InkRouter_Models_Attributes_FoldingAttributes implements InkRouter_Models_
 
     /**
      * @var bool
+     * @deprecated
      */
     private $insideOut;
 
@@ -65,6 +66,7 @@ class InkRouter_Models_Attributes_FoldingAttributes implements InkRouter_Models_
     /**
      * @param bool $insideOut
      * @return InkRouter_Models_Attributes_FoldingAttributes
+     * @deprecated
      */
     public function setInsideOut($insideOut)
     {
@@ -74,6 +76,7 @@ class InkRouter_Models_Attributes_FoldingAttributes implements InkRouter_Models_
 
     /**
      * @return bool
+     * @deprecated
      */
     public function getInsideOut()
     {


### PR DESCRIPTION
In https://github.com/opensoft/ONP/pull/7242 ONP team stopped sending insideOut flag and started to take care of image swapping before sending to JSI. 