### PR TITLE
[master] Removed type casting to int for width and height of a printing asset

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,11 +91,11 @@ Create InkRouter_Models_OrderInfo instance (with example data)
 
     $printAsset = new InkRouter_Models_PrintAsset();
     $printAsset->setPositionX(4.98)
-        ->setPositionY(3)
+        ->setPositionY(3.1)
         ->setRotation(-90)
         ->setType('BARCODE')
-        ->setHeight(3.55)
-        ->setWidth(3.612);
+        ->setHeight(0.543)
+        ->setWidth(2.12);
 
     $side = new InkRouter_Models_Side();
     $side->setPageNumber(10)

--- a/src/InkRouter/Models/PrintAsset.php
+++ b/src/InkRouter/Models/PrintAsset.php
@@ -92,7 +92,7 @@ class InkRouter_Models_PrintAsset
      */
     public function setWidth($width)
     {
-        $this->width = (int) $width;
+        $this->width = $width;
 
         return $this;
     }
@@ -111,7 +111,7 @@ class InkRouter_Models_PrintAsset
      */
     public function setHeight($height)
     {
-        $this->height = (int) $height;
+        $this->height = $height;
 
         return $this;
     }

--- a/tests/InkRouter/Models/OrderInfoTest.php
+++ b/tests/InkRouter/Models/OrderInfoTest.php
@@ -68,11 +68,11 @@ class OrderInfoTest extends PHPUnit_Framework_TestCase
 
         $printAsset = new InkRouter_Models_PrintAsset();
         $printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
 
         $side = new InkRouter_Models_Side();
         $side->setPageNumber(10)

--- a/tests/InkRouter/Models/OrderItemTest.php
+++ b/tests/InkRouter/Models/OrderItemTest.php
@@ -65,11 +65,11 @@ class OrderItemTest extends PHPUnit_Framework_TestCase
     {
         $printAsset = new InkRouter_Models_PrintAsset();
         $printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
 
         $side = new InkRouter_Models_Side();
         $side->setPageNumber(10)

--- a/tests/InkRouter/Models/OrderProcessorTest.php
+++ b/tests/InkRouter/Models/OrderProcessorTest.php
@@ -84,11 +84,11 @@ class OrderProcessorTest extends PHPUnit_Framework_TestCase
 
         $printAsset = new InkRouter_Models_PrintAsset();
         $printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
 
         // order item with envelopes
         $side2 = new InkRouter_Models_Side();

--- a/tests/InkRouter/Models/OrderTest.php
+++ b/tests/InkRouter/Models/OrderTest.php
@@ -60,11 +60,11 @@ class OrderTest extends PHPUnit_Framework_TestCase
 
         $printAsset = new InkRouter_Models_PrintAsset();
         $printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
 
         $side = new InkRouter_Models_Side();
         $side->setPageNumber(10)

--- a/tests/InkRouter/Models/PrintAssetTest.php
+++ b/tests/InkRouter/Models/PrintAssetTest.php
@@ -29,10 +29,10 @@ class PrintAssetTest extends PHPUnit_Framework_TestCase
     {
         $this->printAsset = new InkRouter_Models_PrintAsset();
         $this->printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
     }
 }

--- a/tests/InkRouter/Models/SideTest.php
+++ b/tests/InkRouter/Models/SideTest.php
@@ -25,11 +25,11 @@ class SideTest extends PHPUnit_Framework_TestCase
     {
         $printAsset = new InkRouter_Models_PrintAsset();
         $printAsset->setPositionX(4.98)
-            ->setPositionY(3)
+            ->setPositionY(3.1)
             ->setRotation(-90)
             ->setType('BARCODE')
-            ->setHeight(3.55)
-            ->setWidth(3.612);
+            ->setHeight(0.543)
+            ->setWidth(2.12);
 
         $this->side = new InkRouter_Models_Side();
         $this->side->setPageNumber(10)

--- a/tests/InkRouter/fixtures/order.xml
+++ b/tests/InkRouter/fixtures/order.xml
@@ -67,9 +67,9 @@
           <print_assets>
             <print_asset>
               <position_x>4.98</position_x>
-              <position_y>3</position_y>
-              <width>3</width>
-              <height>3</height>
+              <position_y>3.1</position_y>
+              <width>2.12</width>
+              <height>0.543</height>
               <type>BARCODE</type>
               <rotation>-90</rotation>
             </print_asset>

--- a/tests/InkRouter/fixtures/order_info.xml
+++ b/tests/InkRouter/fixtures/order_info.xml
@@ -75,9 +75,9 @@
             <print_assets>
               <print_asset>
                 <position_x>4.98</position_x>
-                <position_y>3</position_y>
-                <width>3</width>
-                <height>3</height>
+                <position_y>3.1</position_y>
+                <width>2.12</width>
+                <height>0.543</height>
                 <type>BARCODE</type>
                 <rotation>-90</rotation>
               </print_asset>

--- a/tests/InkRouter/fixtures/order_item.xml
+++ b/tests/InkRouter/fixtures/order_item.xml
@@ -27,9 +27,9 @@
         <print_assets>
           <print_asset>
             <position_x>4.98</position_x>
-            <position_y>3</position_y>
-            <width>3</width>
-            <height>3</height>
+            <position_y>3.1</position_y>
+            <width>2.12</width>
+            <height>0.543</height>
             <type>BARCODE</type>
             <rotation>-90</rotation>
           </print_asset>

--- a/tests/InkRouter/fixtures/order_processor.xml
+++ b/tests/InkRouter/fixtures/order_processor.xml
@@ -80,9 +80,9 @@
                     <print_assets>
                       <print_asset>
                         <position_x>4.98</position_x>
-                        <position_y>3</position_y>
-                        <width>3</width>
-                        <height>3</height>
+                        <position_y>3.1</position_y>
+                        <width>2.12</width>
+                        <height>0.543</height>
                         <type>BARCODE</type>
                         <rotation>-90</rotation>
                       </print_asset>

--- a/tests/InkRouter/fixtures/print_asset.xml
+++ b/tests/InkRouter/fixtures/print_asset.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <print_asset>
     <position_x>4.98</position_x>
-    <position_y>3</position_y>
-    <width>3</width>
-    <height>3</height>
+    <position_y>3.1</position_y>
+    <width>2.12</width>
+    <height>0.543</height>
     <type>BARCODE</type>
     <rotation>-90</rotation>
 </print_asset>

--- a/tests/InkRouter/fixtures/side.xml
+++ b/tests/InkRouter/fixtures/side.xml
@@ -11,9 +11,9 @@
   <print_assets>
     <print_asset>
       <position_x>4.98</position_x>
-      <position_y>3</position_y>
-      <width>3</width>
-      <height>3</height>
+      <position_y>3.1</position_y>
+      <width>2.12</width>
+      <height>0.543</height>
       <type>BARCODE</type>
       <rotation>-90</rotation>
     </print_asset>


### PR DESCRIPTION
After switching from pixels to inches i forgot to remove type casting for width and height of print assets so we had only int values there. And for those fields in tests i used int values so they didn't helped.

Casting removed, tests updated to be more helpful

