### PR TITLE
[TFS-30544] Add notepads attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: php
 
 php:
+  - 5.3
+  - 5.4
+  - 5.5
   - 5.6
+  - 7.0
 
 script: phpunit --coverage-text
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  - 5.2
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
 
 script: phpunit --coverage-text
 

--- a/src/InkRouter/Models/Attributes/NotepadsAttributes.php
+++ b/src/InkRouter/Models/Attributes/NotepadsAttributes.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @author James Taylor <james.taylor@opensoftdev.com>
+ */
+class InkRouter_Models_Attributes_NotepadsAttributes implements InkRouter_Models_Attributes_AttributeInterface
+{
+    /**
+     * @var int
+     */
+    private $pages;
+
+    /**
+     * @param int $pages
+     * @return InkRouter_Models_Attributes_NotepadsAttributes
+     */
+    public function setPages($pages)
+    {
+        $this->pages = $pages;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPages()
+    {
+        return $this->pages;
+    }
+
+    /**
+     * @param bool $root
+     * @return string
+     */
+    public function pack($root = false)
+    {
+        $writer = new XMLWriter();
+        $writer->openMemory();
+        if ($root) {
+            $writer->startDocument();
+        }
+
+        $writer->startElement('notepads_attributes');
+
+        if (isset($this->pages)) {
+            $writer->writeElement('pages', $this->pages);
+        }
+
+        $writer->endElement();
+
+        return $writer->outputMemory();
+    }
+}

--- a/tests/InkRouter/Models/Attributes/NotepadsAttributesTest.php
+++ b/tests/InkRouter/Models/Attributes/NotepadsAttributesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @author James Taylor <james.taylor@opensoftdev.com>
+ */
+class NotepadsAttributesTest extends PHPUnit_Framework_TestCase
+{
+    private $attributes;
+
+    protected function setUp()
+    {
+        $this->attributes = new InkRouter_Models_Attributes_NotepadsAttributes();
+        $this->attributes->setPages(50);
+    }
+
+    public function testPackWithRoot()
+    {
+        $this->assertXmlStringEqualsXmlFile(dirname(__FILE__) . '/../../fixtures/notepads_attributes.xml', $this->attributes->pack(true));
+    }
+
+    public function testPackWithoutRoot()
+    {
+        $this->assertXmlStringEqualsXmlFile(dirname(__FILE__) . '/../../fixtures/notepads_attributes.xml', $this->attributes->pack());
+    }
+}

--- a/tests/InkRouter/fixtures/notepads_attributes.xml
+++ b/tests/InkRouter/fixtures/notepads_attributes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<notepads_attributes>
+    <pages>50</pages>
+</notepads_attributes>


### PR DESCRIPTION
New XML schema supposedly has this new element called notepads_attributes with a child called pages.

So... Here's where we add it. Need to increment the version and update composer for onp

