### PR TITLE
Implement support null values via xsi:nil specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 before_script: composer install
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         "php": ">=5.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "5.7.*"
     }
 }

--- a/src/InkRouter/Response/Response.php
+++ b/src/InkRouter/Response/Response.php
@@ -34,45 +34,52 @@ class InkRouter_Response_Response
         foreach ($xml->getElementsByTagName('client_update') as $update) {
             $updateObj = new InkRouter_Response_Update();
             foreach ($update->childNodes as $property) {
+                $nodeValue = $property->nodeValue;
+                if ($property->attributes && $property->attributes->length > 0) {
+                    $nil = $property->attributes->getNamedItem('nil');
+                    if ($nil->value === 'true') {
+                        $nodeValue = null;
+                    }
+                }
                 switch ($property->nodeName) {
                     case 'update_id':
-                        $updateObj->setId($property->nodeValue);
+                        $updateObj->setId($nodeValue);
                         break;
                     case 'update_type':
-                        $updateObj->setType($property->nodeValue);
+                        $updateObj->setType($nodeValue);
                         break;
                     case 'quantity':
-                        $updateObj->setQuantity($property->nodeValue);
+                        $updateObj->setQuantity($nodeValue);
                         break;
                     case 'order_item_id':
-                        $updateObj->setOrderItemId($property->nodeValue);
+                        $updateObj->setOrderItemId($nodeValue);
                         break;
                     case 'comment':
-                        $updateObj->setComment($property->nodeValue);
+                        $updateObj->setComment($nodeValue);
                         break;
                     case 'replyUrl':
-                        $updateObj->setReplyUrl($property->nodeValue);
+                        $updateObj->setReplyUrl($nodeValue);
                         break;
                     case 'timestamp':
-                        $updateObj->setTimestamp($property->nodeValue);
+                        $updateObj->setTimestamp($nodeValue);
                         break;
                     case 'print_customer_invoice':
-                        $updateObj->setPrintCustomerInvoice($property->nodeValue);
+                        $updateObj->setPrintCustomerInvoice($nodeValue);
                         break;
                     case 'misc':
-                        $updateObj->setMisc($property->nodeValue);
+                        $updateObj->setMisc($nodeValue);
                         break;
                     case 'tracking_number':
-                        $updateObj->setTrackingNumber($property->nodeValue);
+                        $updateObj->setTrackingNumber($nodeValue);
                         break;
                     case 'weight':
-                        $updateObj->setWeight($property->nodeValue);
+                        $updateObj->setWeight($nodeValue);
                         break;
                     case 'cost':
-                        $updateObj->setCost($property->nodeValue);
+                        $updateObj->setCost($nodeValue);
                         break;
                     case 'print_provider_invoice':
-                        $updateObj->setPrintProviderInvoice($property->nodeValue);
+                        $updateObj->setPrintProviderInvoice($nodeValue);
                         break;
                 }
             }

--- a/tests/InkRouter/Response/ResponseTest.php
+++ b/tests/InkRouter/Response/ResponseTest.php
@@ -27,8 +27,24 @@ class ResponseTest extends PHPUnit_Framework_TestCase
             ->setWeight(10.2)
             ->setCost(11.1)
             ->setPrintProviderInvoice('1236433fd1123rf');
+
+        $updateShip = new InkRouter_Response_Update();
+        $updateShip->setId(3)
+            ->setType('SHIP')
+            ->setQuantity(500)
+            ->setOrderItemId('pg4f7969f8a4891')
+            ->setComment("SHIPPING_VENDOR: 'DHL_EXPRESS';SHIP_TYPE: '0';BOX ID: '0';")
+            ->setReplyUrl('')
+            ->setTimestamp(123456789)
+            ->setPrintCustomerInvoice('123a33412fg11')
+            ->setMisc('misc')
+            ->setTrackingNumber('1234lfdsaj23434')
+            ->setWeight(10.2)
+            ->setCost(null)
+            ->setPrintProviderInvoice('1236433fd1123rf');
         
-        $this->assertEquals(array($update), $response->getUpdates());
+        $this->assertEquals(array($update, $updateShip), $response->getUpdates());
+        $this->assertNull($response->getUpdates()[1]->getCost());
     }
 
     protected function setUp()

--- a/tests/InkRouter/fixtures/client_updates.xml
+++ b/tests/InkRouter/fixtures/client_updates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<client_updates>
+<client_updates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <client_update>
         <update_id>2</update_id>
         <update_type>PRINT</update_type>
@@ -13,6 +13,21 @@
         <tracking_number>1234lfdsaj23434</tracking_number>
         <weight>10.2</weight>
         <cost>11.1</cost>
+        <print_provider_invoice>1236433fd1123rf</print_provider_invoice>
+    </client_update>
+    <client_update>
+        <update_id>3</update_id>
+        <update_type>SHIP</update_type>
+        <quantity>500</quantity>
+        <order_item_id>pg4f7969f8a4891</order_item_id>
+        <comment>SHIPPING_VENDOR: 'DHL_EXPRESS';SHIP_TYPE: '0';BOX ID: '0';</comment>
+        <replyUrl />
+        <timestamp>123456789</timestamp>
+        <print_customer_invoice>123a33412fg11</print_customer_invoice>
+        <misc>misc</misc>
+        <tracking_number>1234lfdsaj23434</tracking_number>
+        <weight>10.2</weight>
+        <cost xsi:nil="true" />
         <print_provider_invoice>1236433fd1123rf</print_provider_invoice>
     </client_update>
 </client_updates>


### PR DESCRIPTION
UK problem with SHIP Update
In Master branch cost is an empty string but should null following our specification.

<client_updates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <Updates>
    <client_update>
      <Id>636953433926894912</Id>
      <update_id>0</update_id>
      <update_type>SHIP</update_type>
      <print_provider_invoice>1000147236</print_provider_invoice>
      <comment>SHIPPING_VENDOR: 'DHL_EXPRESS'; SHIP_TYPE: '0'; BOX ID: '0';</comment>
      <ReplyUrl />
      <print_customer_invoice>986394167</print_customer_invoice>
      <order_item_id>pg5cf4fc766f076</order_item_id>
      <quantity>100</quantity>
      <tracking_number>7325100086</tracking_number>
      <weight>0.18</weight>
      <cost
        xsi:nil="true" />
    </client_update>
  </Updates>
</client_updates>